### PR TITLE
fixes overnight shift where end day is in the next month and not sunday

### DIFF
--- a/app/src/main/java/com/example/oddhours/ui/home/HomeAdapter.kt
+++ b/app/src/main/java/com/example/oddhours/ui/home/HomeAdapter.kt
@@ -340,7 +340,7 @@ class HomeAdapter(private var jobList: List<JobModel>, val context: Context, pri
         // below variables help fix issue when startDate and endDate are at the end of the 7 day cycle and it's either
         // the same month or a different month. we want to ensure the overlap is still exactly one day
         val oneDayOverlapSameMonth = endDateDay - startDateDay == 1
-        val oneDayOverlapDiffMonth = (startDateDayOfWeek == 7 && endDateDayOfWeek == 1) && (endDateMonth - startDateMonth == 1)
+        val oneDayOverlapDiffMonth = ((startDateDayOfWeek == 7 && endDateDayOfWeek == 1) || (startDateDayOfWeek == endDateDayOfWeek-1)) && (endDateMonth - startDateMonth == 1)
         val oneDayOverlap = oneDayOverlapSameMonth || oneDayOverlapDiffMonth
 
         // DEBUG LOGS (uncomment following log lines for more information in logcat

--- a/app/src/main/java/com/example/oddhours/ui/shifts/ChildAdapter.kt
+++ b/app/src/main/java/com/example/oddhours/ui/shifts/ChildAdapter.kt
@@ -292,7 +292,7 @@ class ChildAdapter(private var shiftsList: List<ShiftsModel>, val context: Conte
         // below variables help fix issue when startDate and endDate are at the end of the 7 day cycle and it's either
         // the same month or a different month. we want to ensure the overlap is still exactly one day
         val oneDayOverlapSameMonth = endDateDay - startDateDay == 1
-        val oneDayOverlapDiffMonth = (startDateDayOfWeek == 7 && endDateDayOfWeek == 1) && (endDateMonth - startDateMonth == 1)
+        val oneDayOverlapDiffMonth = ((startDateDayOfWeek == 7 && endDateDayOfWeek == 1) || (startDateDayOfWeek == endDateDayOfWeek-1)) && (endDateMonth - startDateMonth == 1)
         val oneDayOverlap = oneDayOverlapSameMonth || oneDayOverlapDiffMonth
 
         // DEBUG LOGS (uncomment following log lines for more information in logcat


### PR DESCRIPTION
using the Calendar.DAY_OF_WEEK function to figure out if our shift is an overnight shift, we only took into consideration if the days are also at the end of the week cycle. this fix handles the case where end day is any other day. below is a list of days of the week and their number representations from the Calendar object
sun - 1
mon - 2
tues - 3
wed - 4
thurs - 5
fri - 6
sat - 7