### PR TITLE
adds viewBinding library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildFeatures {
+        viewBinding true // https://linear.app/oddhours/issue/ODD-30/kotlin-android-extensions-deprecated
+    }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
adds viewBinding library in case we really need to remove kotlin-android-extensions library